### PR TITLE
Correctly raise EmptyFileImportError if excel file empty.

### DIFF
--- a/lib/table_importer/excel.rb
+++ b/lib/table_importer/excel.rb
@@ -51,7 +51,7 @@ module TableImporter
         else
           lines[0..8]
         end
-      rescue SystemStackError
+      rescue SystemStackError, NoMethodError
         raise TableImporter::EmptyFileImportError.new
       end
     end


### PR DESCRIPTION
Catches NilClass error that is raised if Excel file has no valid email addresses.
